### PR TITLE
[Server] / #44 / fix: sequelize 위도, 경도 관련 스키마 구조 변경

### DIFF
--- a/server/migrations/20220103052427-create-user.js
+++ b/server/migrations/20220103052427-create-user.js
@@ -20,6 +20,14 @@ module.exports = {
         allowNull: false,
         type: Sequelize.STRING
       },
+      latitude: {
+        allowNull: false,
+        type: Sequelize.DOUBLE
+      },
+      longitude: {
+        allowNull: false,
+        type: Sequelize.DOUBLE
+      },
       created_at: {
         allowNull: false,
         type: Sequelize.DATE

--- a/server/migrations/20220103053012-create-store.js
+++ b/server/migrations/20220103053012-create-store.js
@@ -16,11 +16,11 @@ module.exports = {
       },
       latitude: {
         allowNull: false,
-        type: Sequelize.DECIMAL
+        type: Sequelize.DOUBLE
       },
       longitude: {
         allowNull: false,
-        type: Sequelize.DECIMAL
+        type: Sequelize.DOUBLE
       }
     });
   },

--- a/server/models/store.js
+++ b/server/models/store.js
@@ -20,8 +20,8 @@ module.exports = (sequelize, DataTypes) => {
     },
     address: DataTypes.STRING,
     image: DataTypes.TEXT,
-    latitude: DataTypes.DECIMAL,
-    longitude: DataTypes.DECIMAL
+    latitude: DataTypes.DOUBLE,
+    longitude: DataTypes.DOUBLE
   }, {
     sequelize,
     modelName: 'store',

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -21,6 +21,8 @@ module.exports = (sequelize, DataTypes) => {
     user_id: DataTypes.STRING,
     pw: DataTypes.STRING,
     name: DataTypes.STRING,
+    latitude: DataTypes.DOUBLE,
+    longitude: DataTypes.DOUBLE,
     created_at: DataTypes.DATE
   }, {
     sequelize,

--- a/server/seeders/20220103065958-dummy-user.js
+++ b/server/seeders/20220103065958-dummy-user.js
@@ -10,6 +10,8 @@ module.exports = {
         user_id: "test01",
         pw: "password01",
         name: "테스트01",
+        latitude: 37.531847120450514,
+        longitude: 126.9142190711598,
         created_at: new Date("2022-01-01")
       },
       {
@@ -17,6 +19,8 @@ module.exports = {
         user_id: "test02",
         pw: "password02",
         name: "테스트02",
+        latitude: 37.49605498475844, 
+        longitude: 127.01133120203217,
         created_at: new Date("2022-01-03")
       }
     ];


### PR DESCRIPTION
### PR 타입
- [x] 파일 수정

### 반영 브랜치
feature/44 -> dev

### 변경 사항
- user 테이블에 latitude, longitude 컬럼 생성
- store 테이블의 latitude, longitude 컬럼의 타입을 double로 변경

### 테스트 결과
- rds측 test DB에서 마이그레이션 및 시드 생성 확인됨

### 관련 이슈
- https://github.com/codestates/BaroYeogiya/issues/44