### PR TITLE
[Server] / #60 / fix: users API 수정 및 비밀번호 확인 API 추가

### DIFF
--- a/server/controllers/users/common.js
+++ b/server/controllers/users/common.js
@@ -1,6 +1,6 @@
 const { v4 } = require('uuid');
 const { user } = require('../../models');
-const { generate, hash, refresh } = require('../../utils/token');
+const { generate, hash } = require('../../utils/token');
 
 /**
  * @path /user
@@ -53,7 +53,7 @@ module.exports = {
     /**
      * 회원정보 조회 API
      * @method GET
-     * @param { authorization } req.header
+     * @param { authorization } req.headers
      */
     get: (req, res) => {
         const hashData = hash(req.headers);
@@ -98,7 +98,7 @@ module.exports = {
     /**
      * 회원정보 수정 API
      * @method PATCH
-     * @param { authorization } req.header
+     * @param { authorization } req.headers
      * @param { pw, name } req.body
      */
     patch: (req, res) => {
@@ -131,9 +131,11 @@ module.exports = {
 
                         res.status(400).send({ message });
                     } else {
+                        const tokenData = generate(uuid, user_id);
                         message = 'Success!';
-                        data = generate(uuid, user_id);
+                        data.accessToken = tokenData.accessToken;
 
+                        res.cookie('refresh', tokenData.refreshToken, { maxAge: 86400000 });
                         res.status(200).send({ message, data });
                     }
                 })
@@ -152,7 +154,7 @@ module.exports = {
     },
     /**
      * 회원정보 삭제 API
-     * @param { authorization } req.header
+     * @param { authorization } req.headers
      */
     delete: (req, res) => {
         const hashData = hash(req.headers);

--- a/server/controllers/users/index.js
+++ b/server/controllers/users/index.js
@@ -1,5 +1,6 @@
 const common = require('./common');
 const login = require('./login');
+const pwConfirm = require('./pwConfirm');
 const refresh = require('./refresh');
 
-module.exports = { common, login, refresh };
+module.exports = { common, login, pwConfirm, refresh };

--- a/server/controllers/users/login.js
+++ b/server/controllers/users/login.js
@@ -1,6 +1,5 @@
-const { v4 } = require('uuid');
 const { user } = require('../../models');
-const { generate, hash, refresh } = require('../../utils/token');
+const { generate } = require('../../utils/token');
 
 /**
  * @path /user/login
@@ -36,10 +35,11 @@ module.exports = {
                     res.status(400).send({ message });
                 // access token과 refresh token 생성
                 } else {
-                    const user_uuid = result.uuid;
-
+                    const tokenData = generate(result.uuid, id);
                     message = 'Success!';
-                    data = generate(user_uuid, id);
+                    data.accessToken = tokenData.accessToken;
+
+                    res.cookie('refresh', tokenData.refreshToken, { maxAge: 86400000 });
                     res.status(200).send({ message, data });
                 }
             })

--- a/server/controllers/users/pwConfirm.js
+++ b/server/controllers/users/pwConfirm.js
@@ -1,0 +1,62 @@
+const { user } = require('../../models');
+const { hash } = require('../../utils/token');
+
+/**
+ * @path /user/pw-confirm
+ */
+ module.exports = {
+    /**
+     * 비밀번호 확인 API
+     * @method GET
+     * @param { authorization } req.headers
+     * @param { pw } req.query
+     */
+    get: (req, res) => {
+        const hashData = hash(req.headers);
+        const { pw } = req.query;
+        let message = '';
+        let data = {};
+
+        // 회원정보 조회
+        if (hashData.uuid !== undefined) {
+            // parameter 유무 확인
+            if (pw === undefined) {
+                message = 'Check your parameter.';
+
+                res.status(400).send({ message });
+            } else {
+                const { uuid, user_id } = hashData;
+
+                user.findOne({
+                    where: {
+                        uuid,
+                        user_id,
+                        pw
+                    }
+                }).then(result => {
+                    // 아이디 혹은 비밀번호가 일치하지 않음
+                    if (result === null) {
+                        message = 'Does not match password.';
+    
+                        res.status(400).send({ message });
+                    // access token과 refresh token 생성
+                    } else {
+                        message = 'Success!';
+
+                        res.status(200).send({ message });
+                    }
+                })
+            }
+        // 액세스 토큰 만료 처리
+        } else if (hashData) {
+            message = 'The access token has expired.';
+
+            res.status(401).send({ message });
+        // 액세스 토큰이 잘못됨
+        } else {
+            message = 'Check your access token.';
+
+            res.status(401).send({ message });
+        }
+    }
+}

--- a/server/controllers/users/refresh.js
+++ b/server/controllers/users/refresh.js
@@ -1,6 +1,4 @@
-const { v4 } = require('uuid');
-const { user } = require('../../models');
-const { generate, hash, refresh } = require('../../utils/token');
+const { refresh } = require('../../utils/token');
 
 /**
  * @path /user/refresh
@@ -11,17 +9,18 @@ module.exports = {
      * @param { refreshToken } req.cookies
      */
     get: (req, res) => {
-        const refreshData = refresh(req.cookies);
+        const tokenData = refresh(req.cookies);
         let message = '';
         let data = {};
 
-        console.log(req.cookies);
-        if (refreshData.accessToken !== undefined) {
+        console.log(tokenData.accessToken);
+        if (tokenData.accessToken !== undefined) {
             message = 'Success!';
-            data = refreshData;
+            data.accessToken = tokenData.accessToken;
             
+            res.cookie('refresh', tokenData.refreshToken, { maxAge: 86400000 });
             res.status(200).send({ message, data });
-        } else if (refreshData) {
+        } else if (tokenData) {
             message = 'The refresh token has expired.';
 
             res.status(400).send({ message });

--- a/server/router.js
+++ b/server/router.js
@@ -13,6 +13,8 @@ userRouter.patch('/', userController.common.patch);
 userRouter.delete('/', userController.common.delete);
 // Path: /user/login
 userRouter.get('/login', userController.login.get);
+// Path: /user/pw-confirm
+userRouter.get('/pw-confirm', userController.pwConfirm.get);
 // Path: /user/refresh
 userRouter.get('/refresh', userController.refresh.get);
 

--- a/server/utils/token.js
+++ b/server/utils/token.js
@@ -13,7 +13,7 @@ module.exports = {
         const data = { uuid, user_id, created_at: new Date() };
         const accessToken = jwt.sign(data, process.env.ACCESS_SECRET, { expiresIn: '3h' });
         const refreshToken = jwt.sign(data, process.env.REFRESH_SECRET, { expiresIn: '1d' });
-
+        
         return { accessToken, refreshToken };
     },
     /**
@@ -48,7 +48,7 @@ module.exports = {
      */
     refresh: (cookies) => {
         try {
-            const cookieRefreshToken = cookies.refreshToken;
+            const cookieRefreshToken = cookies.refresh;
             const hashData = jwt.verify(cookieRefreshToken, process.env.REFRESH_SECRET);
             const data = { uuid: hashData.uuid, user_id: hashData.user_id, created_at: new Date() };
             const accessToken = jwt.sign(data, process.env.ACCESS_SECRET, { expiresIn: '3h' });


### PR DESCRIPTION
### PR 타입
- [x] 파일 수정

### 반영 브랜치
feature/60 -> dev

### 변경 사항
- refresh token이 쿠키에 담기도록 변경
- `GET` /user/pw-confirm API 추가

### 테스트 결과
- 로컬 테스트 완료

### 관련 이슈
- https://github.com/codestates/BaroYeogiya/issues/60