### PR TITLE
[Server] / #76 / fix: 핀 조회 API 파라미터 수정

### DIFF
--- a/server/controllers/maps/pin.js
+++ b/server/controllers/maps/pin.js
@@ -10,23 +10,27 @@ module.exports = {
      * 핀 조회 API
      * @method GET
      * @param { authorization } req.headers
-     * @param { start_latitude, end_latitude, start_longitude, end_longitude, like } req.body
+     * @param { latitude, longitude, like } req.query
      */
     get: (req, res) => {
         const hashData = hash(req.headers);
-        const { start_latitude, end_latitude, start_longitude, end_longitude, like } = req.body;
+        const { like } = req.query;
+        let { latitude, longitude } = req.query;
         let message = '';
         let data = [];
+
+        latitude = Number(latitude);
+        longitude = Number(longitude);
 
         // access token 확인
         if (like === undefined || (like !== undefined && hashData.uuid !== undefined)) {
             // parameter 유무 확인
-            if (start_latitude === undefined || end_latitude === undefined || start_longitude === undefined || end_longitude === undefined) {
+            if (isNaN(latitude) || isNaN(longitude)) {
                 message = 'Check your parameter.';
     
                 res.status(400).send({ message });
             } else {
-                const { uuid, user_id } = hashData;
+                const { uuid } = hashData;
                 let include;
 
                 // like parameter가 true일 때만 테이블 조인
@@ -47,10 +51,10 @@ module.exports = {
                     include,
                     where: {
                         latitude: {
-                            [Op.between]: [start_latitude, end_latitude]
+                            [Op.between]: [latitude - 0.5, latitude + 0.5]
                         },
                         longitude: {
-                            [Op.between]: [start_longitude, end_longitude]
+                            [Op.between]: [longitude - 0.5, longitude + 0.5]
                         }
                     },
                     attributes: [


### PR DESCRIPTION
### PR 타입
- [x] 파일 수정

### 반영 브랜치
feature/76 -> dev

### 변경 사항
- 요구 쿼리 파라미터 변경(start_latitude, end_latitude, start_longitude, end_longitude -> latitude, longitude)
- 이제 중심 좌표만 보내면 +-0.5의 범위 안의 위도와 경도를 검색함

### 테스트 결과
- 로컬 테스트 완료

### 관련 이슈
- https://github.com/codestates/BaroYeogiya/issues/76