### PR TITLE
[Client] / #84 / 회원 정보 수정, 탈퇴 작업 중 로고의 마이페이지 클릭 시, 회원정보가 다시 렌더되도록 수정

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,7 +12,21 @@ function App() {
   const [isLogin, setIsLogin] = useState(false);
   const [userInfo, setUserInfo] = useState(null);
   // console.log(isLogin)
+  const [withDrawalModal, setWithDrawlalModal] = useState(false);
+  const [modifyModal, setModifyModal] = useState(false);
+  const handleWithDrawalModal = () => {
+    setWithDrawlalModal(true);
+    setModifyModal(false);
+  };
 
+  const handleModifyModal = () => {
+    setModifyModal(true);
+    setWithDrawlalModal(false);
+  };
+  const handleInitializeMypage = () => {
+    setModifyModal(false);
+    setWithDrawlalModal(false);
+  };
   const handleResponse = (res) => {
     // accessToken을 받아 와서 state에 저장한다.
     const userInfo = {
@@ -38,6 +52,7 @@ function App() {
           <UserNavBar
             handleResponse={handleResponse}
             handleIsLogin={handleIsLogin}
+            handleInitializeMypage={handleInitializeMypage}
           />
         ) : (
           <NavBar
@@ -55,7 +70,16 @@ function App() {
           <Route
             exact
             path="/mypage"
-            element={<Mypage userInfo={userInfo} />}
+            element={
+              <Mypage
+                userInfo={userInfo}
+                handleWithDrawalModal={handleWithDrawalModal}
+                handleModifyModal={handleModifyModal}
+                withDrawalModal={withDrawalModal}
+                modifyModal={modifyModal}
+                handleIsLogin={handleIsLogin}
+              />
+            }
           ></Route>
           <Route exact path="/mappage" element={<Map />}></Route>
         </Routes>

--- a/client/src/Components/UserNavBar.js
+++ b/client/src/Components/UserNavBar.js
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
 import '../Css/NavBar.css';
 import { useNavigate } from 'react-router-dom';
-function UserNavBar({ handleResponse, handleIsLogin }) {
+
+function UserNavBar({ handleResponse, handleIsLogin, handleInitializeMypage }) {
   const onLogout = () => {
     // props로 받은 함수를 실행하여 상태를 변경 시킨다.
     handleResponse({
@@ -24,7 +25,9 @@ function UserNavBar({ handleResponse, handleIsLogin }) {
             <button className="bt">지도</button>
           </Link>
           <Link to="/mypage">
-            <button className="bt">My Page</button>
+            <button onClick={handleInitializeMypage} className="bt">
+              My Page
+            </button>
           </Link>
           <button className="bt" onClick={() => onLogout()}>
             Logout

--- a/client/src/Pages/Mypage.js
+++ b/client/src/Pages/Mypage.js
@@ -4,23 +4,14 @@ import ModifyUser from '../Components/Modals/ModifyUser';
 import UserInfo from '../Components/UserInfo';
 
 // 마이페이지 컴포넌트
-export default function Mypage({ userInfo }) {
-  const [withDrawalModal, setWithDrawlalModal] = useState(false);
-  const [modifyModal, setModifyModal] = useState(false);
-  const handleWithDrawalModal = () => {
-    setWithDrawlalModal(true);
-    setModifyModal(false);
-  };
-
-  const handleModifyModal = () => {
-    setModifyModal(true);
-    setWithDrawlalModal(false);
-  };
-  const handleInitializeMypage = () => {
-    setModifyModal(false);
-    setWithDrawlalModal(false);
-  };
-
+export default function Mypage({
+  userInfo,
+  handleModifyModal,
+  handleWithDrawalModal,
+  withDrawalModal,
+  modifyModal,
+  handleIsLogin,
+}) {
   if (!withDrawalModal && !modifyModal) {
     return (
       <UserInfo
@@ -32,7 +23,7 @@ export default function Mypage({ userInfo }) {
   } else if (modifyModal && !withDrawalModal) {
     return <ModifyUser userInfo={userInfo} />;
   } else if (!modifyModal && withDrawalModal) {
-    return <WithDrawal userInfo={userInfo} />;
+    return <WithDrawal userInfo={userInfo} handleIsLogin={handleIsLogin} />;
   }
   return (
     <>


### PR DESCRIPTION
### PR 타입
 오류 수정
반영 브랜치
feature/84 -> dev

### 변경 사항
회원 정보 수정, 탈퇴 이용시, 마이페이지 버튼 클릭하면 다시 정보조회가 렌더링

### 테스트 결과
정상 작동합니다.
